### PR TITLE
add curl and EXPOSE to Dockerfile.api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ RUN VITE_STORAGE_MODE=$VITE_STORAGE_MODE \
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.config /etc/nginx/conf.d/default.conf
-HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD curl-f http://localhost:3000/health || exit 1
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD curl -f http://localhost:3000/health || exit 1
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,5 @@ RUN VITE_STORAGE_MODE=$VITE_STORAGE_MODE \
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.config /etc/nginx/conf.d/default.conf
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD curl-f http://localhost:3000/health || exit 1
+EXPOSE 80

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -13,6 +13,6 @@ RUN npm run build
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD curl-f http://localhost:3000/health || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD curl -f http://localhost:3000/health || exit 1
 
 CMD ["npm", "start"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -3,10 +3,15 @@ FROM node:18-alpine
 
 WORKDIR /app
 
+
+RUN apk add curl
+
 COPY api/package*.json ./
 RUN npm ci --legacy-peer-deps
 
 COPY api .
 RUN npm run build
+
+EXPOSE 3000
 
 CMD ["npm", "start"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -3,8 +3,7 @@ FROM node:18-alpine
 
 WORKDIR /app
 
-
-RUN apk add curl
+RUN apk add --no-cache curl
 
 COPY api/package*.json ./
 RUN npm ci --legacy-peer-deps
@@ -13,5 +12,7 @@ COPY api .
 RUN npm run build
 
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD curl-f http://localhost:3000/health || exit 1
 
 CMD ["npm", "start"]


### PR DESCRIPTION
Hi,
nice and simple project for BS, great job! After trying to host,  small updates to the Dockerfile.api : 
- add the EXPOSE 3000 (used by a lot of reverse proxies to autoexpose some containers)
- add the curl package (not available by default in node alpine) to repair the container api healthcheck into docker-compose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The application now includes support for the `curl` package.
	- The application will listen on port 3000.
	- The application will now perform health checks every 30 seconds to ensure reliability.
	- The container will listen on port 80 at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->